### PR TITLE
Name the X assay "X"

### DIFF
--- a/R/read_h5mu.R
+++ b/R/read_h5mu.R
@@ -206,7 +206,7 @@ read_modality <- function(view, backed=FALSE) {
         })
     }
 
-    args <- list(assays=c(list(X), layers), rowData=var, colData=obs)
+    args <- list(assays=c(list(X=X), layers), rowData=var, colData=obs)
 
     if ("obsm" %in% viewnames) {
         obsmnames <- h5ls(h5autoclose(view & "obsm"), recursive=FALSE)$name


### PR DESCRIPTION
It doesn't seem to be required that all the assays are named, but I've noticed it breaks various downstream code if it is not.